### PR TITLE
[COOP-584]: Migrate Ex_FuzzyWuzzy to GHAs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
   release:
     runs-on: ubuntu-latest
     steps:
@@ -35,3 +39,5 @@ jobs:
           mix hex.config api_key ${{ secrets.HEX_AUTH_KEY }}
       - name: Publish
         run: mix hex.publish --yes
+    needs:
+      - ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [ "master" ]
+  push:
+    branches: [ "master" ]
   workflow_dispatch: {}
   workflow_call: {}
 


### PR DESCRIPTION
This PR updates the CI to ensure we run the checks after merge to master and before release.

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/COOP-584

